### PR TITLE
Align deployment names and add package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,30 +63,37 @@ The Kubernetes command-line tool. You can install it by following the instructio
 <a name="setup-steps"></a>
 ## 🚀 Setup Steps
 
-1. **Build the Docker image**:
+1. **Start the minikube cluster**:
+    ```shell
+    minikube start
+    ```
+
+2. **(Optional) Use Minikube's Docker daemon**:
+   This allows the Deployment to use the image you build locally.
+   ```shell
+   eval $(minikube docker-env)
+   ```
+
+3. **Build the Docker image**:
 
    Navigate to the repository's root directory and run:
 
    ```shell
    docker build -t my-node-app .
    ```
-   
-2. **Start the minikube cluster**:
-    ```shell
-    minikube start
-    ```
-3. **Deploy the application**:
+
+4. **Deploy the application**:
     Apply the Deployment and Service configurations with the following commands:
     ```shell
     kubectl apply -f my-node-app-deployment.yaml
     kubectl apply -f my-node-app-service.yaml
     ```
-4. **Check the Deployment and Service**:
+5. **Check the Deployment and Service**:
     ```shell
     kubectl get deployments
     kubectl get services
     ```
-5. **Access the application**:
+6. **Access the application**:
     ```shell
     minikube service my-node-app-service
     ```

--- a/my-node-app-deployment.yaml
+++ b/my-node-app-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: node-app-deployment
+  name: my-node-app-deployment
 spec:
   replicas: 3
   selector:
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: node-app-container
-        image: node-app-image:latest
+        image: my-node-app:latest
         ports:
         - containerPort: 3000

--- a/my-node-app-service.yaml
+++ b/my-node-app-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: node-app-service
+  name: my-node-app-service
 spec:
   selector:
     app: node-app

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-node-app",
+  "version": "1.0.0",
+  "description": "Simple Node.js application for Kubernetes demo",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  }
+}


### PR DESCRIPTION
This pull request introduces several changes to improve the setup and deployment process for a Kubernetes-based Node.js application. The most significant updates include reordering the setup steps in the `README.md` for better clarity, renaming resources for consistency, and adding a `package.json` file to define the Node.js application.

### Documentation Updates:
* Reordered the setup steps in `README.md` to start the Minikube cluster before building the Docker image, added an optional step to use Minikube's Docker daemon, and updated step numbering accordingly.

### Resource Renaming for Consistency:
* Renamed the Deployment in `my-node-app-deployment.yaml` from `node-app-deployment` to `my-node-app-deployment` and updated the image name to `my-node-app:latest`. [[1]](diffhunk://#diff-108018da2680d9a59450ee508cf6e62bccebf7a8c630a011f0dce7489eb67a02L4-R4) [[2]](diffhunk://#diff-108018da2680d9a59450ee508cf6e62bccebf7a8c630a011f0dce7489eb67a02L17-R17)
* Renamed the Service in `my-node-app-service.yaml` from `node-app-service` to `my-node-app-service`.

### Application Definition:
* Added a `package.json` file to define the Node.js application, including the application name, version, description, entry point, and start script.## Summary
- fix mismatched resource names in Kubernetes manifests
- align deployment image name with README instructions
- add a simple `package.json`
- clarify README steps to start Minikube before building the Docker image and use the Minikube Docker daemon

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_684ab3e849d0833082edfe46cc6e7e8d